### PR TITLE
Add `--onlyCheckJava` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ BSL creates a new module layer which has the following properties:
 For easier debugging, additional debugging information is printed to `System.out` if the `bsl.debug` system property is
 defined (regardless of its actual value).
 
+## CLI args
+The shim jar accepts the following arguments:
+- `--onlyCheckJava`: If specified, the shim will exit with success code 0 if the Java check passes rather than continuing to launch.
+
 [path_separator]: https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/io/File.html#pathSeparatorChar
 [modlauncher]: https://github.com/MinecraftForge/ModLauncher
 [bootmodule]: https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/ModuleLayer.html#boot()

--- a/bs-api/build.gradle
+++ b/bs-api/build.gradle
@@ -31,7 +31,7 @@ license {
     newLine = false
 }
 
-jar {
+tasks.named('jar', Jar) {
     manifest.attributes([
         'Specification-Title':   'BootStrap-API',
         'Specification-Vendor':  'Forge Development LLC',

--- a/bs-shim/build.gradle
+++ b/bs-shim/build.gradle
@@ -30,7 +30,7 @@ license {
     newLine = false
 }
 
-jar {
+tasks.named('jar', Jar) {
     manifest.attributes([
         'Automatic-Module-Name': 'net.minecraftforge.bootstrap.shim',
         'Main-Class':            'net.minecraftforge.bootstrap.shim.Main'

--- a/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
+++ b/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
@@ -21,6 +21,19 @@ import java.util.Properties;
 public class Main {
     private static final boolean DEBUG = Boolean.getBoolean("bss.debug");
     public static void main(String[] args) throws Exception {
+        Properties props = new Properties();
+        try (InputStream stream = getStream("bootstrap-shim.properties")) {
+            props.load(stream);
+        }
+
+        int wantedJavaVersion = Integer.parseInt(props.getProperty("Java-Version", "0"));
+        int currentJavaVersion = getJavaVersion();
+        if (wantedJavaVersion > currentJavaVersion)
+            throw new IllegalStateException("Current Java is " + System.getProperty("java.version") + " but we require at least " + wantedJavaVersion);
+
+        if (args.length > 0 && args[0].equals("--onlyCheckJava"))
+            System.exit(0);
+
         boolean failed = false;
         List<URL> urls = new ArrayList<>();
         StringBuilder classpath = new StringBuilder(System.getProperty("java.class.path"));
@@ -51,16 +64,6 @@ public class Main {
 
         if (failed)
             throw new IllegalStateException("Missing required libraries! Check log");
-
-        Properties props = new Properties();
-        try (InputStream stream = getStream("bootstrap-shim.properties")) {
-            props.load(stream);
-        }
-
-        int wantedJavaVersion = Integer.parseInt(props.getProperty("Java-Version", "0"));
-        int currentJavaVersion = getJavaVersion();
-        if (wantedJavaVersion > currentJavaVersion)
-            throw new IllegalStateException("Current java is " + System.getProperty("java.version") + " but we require atleast " + wantedJavaVersion);
 
         String mainClass = props.getProperty("Main-Class");
         if (mainClass == null)

--- a/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
+++ b/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
@@ -19,10 +19,10 @@ import java.util.List;
 import java.util.Properties;
 
 public class Main {
-    static final boolean DEBUG = Boolean.getBoolean("bss.debug");
+    private static final boolean DEBUG = Boolean.getBoolean("bss.debug");
     public static void main(String[] args) throws Exception {
         boolean failed = false;
-        List<URL> urls = new ArrayList<URL>();
+        List<URL> urls = new ArrayList<>();
         StringBuilder classpath = new StringBuilder(System.getProperty("java.class.path"));
 
         try (
@@ -109,7 +109,7 @@ public class Main {
 
     private static int getJavaVersion() {
         String version = System.getProperty("java.version");
-        if (version.startsWith("1."))  // Pre Java 9 they all started with 1.
+        if (version.startsWith("1."))  // Pre-Java 9 they all started with "1."
             version = version.substring(2);
 
         int dot = version.indexOf(".");
@@ -119,13 +119,13 @@ public class Main {
         return Integer.parseInt(version);
     }
 
-    private static class ListEntry {
+    private static final class ListEntry {
         private final String sha256;
         //private final String id;
         private final String path;
 
         private static ListEntry from(String line) {
-            String[] parts = line.split("\t");
+            String[] parts = line.split("\t", 3);
             return new ListEntry(parts[0], parts[1], parts[2]);
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ license {
     newLine = false
 }
 
-jar {
+tasks.named('jar', Jar) {
     manifest.attributes([
         'Specification-Title':   'BootStrap',
         'Specification-Vendor':  'Forge Development LLC',
@@ -51,7 +51,7 @@ publishing {
         artifactId = 'bootstrap'
         pom {
             name = 'Bootstrap'
-            description = 'Allows bootstrapping a modularized environment from a classpath one, the intention is for this to be a project where we can bootstrap many different environements of Forge.'
+            description = 'Allows bootstrapping a modularized environment from a classpath one, the intention is for this to be a project where we can bootstrap many different environments of Forge.'
             url = 'https://github.com/MinecraftForge/Bootstrap'
             PomUtils.setGitHubDetails(pom, 'Bootstrap')
             license PomUtils.Licenses.LGPLv3

--- a/src/main/java/net/minecraftforge/bootstrap/ClassPathHelper.java
+++ b/src/main/java/net/minecraftforge/bootstrap/ClassPathHelper.java
@@ -65,8 +65,7 @@ class ClassPathHelper {
                 if ("default".equals(sourceset))
                     continue;
 
-                var parent1 = getParent(1, path);
-                if ("bin".equals(parent1)) {
+                if ("bin".equals(getParent(1, path))) {
                     /*
                      * Eclipse shoves both classes and resources into the same folder
                      *   forge\bin\main
@@ -74,7 +73,7 @@ class ClassPathHelper {
                      *   forge\bin\default
                      */
                     prj = getProjectName(2, path);
-                } else if ("resources".equals(parent1)) {
+                } else if ("resources".equals(getParent(1, path))) {
                     /*
                      * IntelliJ/Gradle resources:
                      *   forge\build\resources\main

--- a/src/main/java/net/minecraftforge/bootstrap/ClassPathHelper.java
+++ b/src/main/java/net/minecraftforge/bootstrap/ClassPathHelper.java
@@ -65,7 +65,8 @@ class ClassPathHelper {
                 if ("default".equals(sourceset))
                     continue;
 
-                if ("bin".equals(getParent(1, path))) {
+                var parent1 = getParent(1, path);
+                if ("bin".equals(parent1)) {
                     /*
                      * Eclipse shoves both classes and resources into the same folder
                      *   forge\bin\main
@@ -73,7 +74,7 @@ class ClassPathHelper {
                      *   forge\bin\default
                      */
                     prj = getProjectName(2, path);
-                } else if ("resources".equals(getParent(1, path))) {
+                } else if ("resources".equals(parent1)) {
                     /*
                      * IntelliJ/Gradle resources:
                      *   forge\build\resources\main
@@ -89,7 +90,7 @@ class ClassPathHelper {
                     prj = getProjectName(4, path);
                 }
 
-                if (prj != null && sourceset != null) {
+                if (prj != null) {
                     //if (DEBUG) log("Found Project `" + prj + "` SourceSet `" + sourceset + "` Directory: " + path);
                     var lst = sourcesets
                         .computeIfAbsent(prj, n -> new HashMap<>())
@@ -164,7 +165,7 @@ class ClassPathHelper {
         var jars = new TreeMap<String, SecureJar>();
         for (var info : modules.values()) {
             var paths = new ArrayList<Path>(info.paths.size());
-            info.paths.forEach(paths::add);
+            paths.addAll(info.paths);
             Collections.reverse(paths); // Securejar is last win instead of first win like the classpath
             /*
             var debug = DEBUG && paths.size() > 1;
@@ -175,7 +176,7 @@ class ClassPathHelper {
             }
             */
 
-            var securejar = SecureJar.from(jar -> getMetadata(jar, info), paths.stream().toArray(Path[]::new));
+            var securejar = SecureJar.from(jar -> getMetadata(jar, info), paths.toArray(Path[]::new));
             jars.put(securejar.moduleDataProvider().name(), securejar);
 
             /*


### PR DESCRIPTION
Checks if the Java requirement is met and either crashes with the friendly error message or gracefully exits without launching. Useful for run scripts (exit code 0 means all good, any other exit code means there's a problem with Java).

To speed up the check, it is moved to the start - before any classpath loading.