### PR TITLE
Optimise parsing `bootstrap-shim.list`

### DIFF
--- a/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
+++ b/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
@@ -46,11 +46,17 @@ public class Main {
                 System.out.println("Loading classpath: ");
             String line = reader.readLine();
             while (line != null) {
-                ListEntry entry = ListEntry.from(line);
-                //System.out.println(entry);
-                File target = new File("libraries/"+ entry.path);
+                String entryPath;
+                if (DEBUG) {
+                    ListEntry entry = ListEntry.from(line);
+                    entryPath = entry.path;
+                    System.out.println(entry);
+                } else {
+                    entryPath = ListEntry.getPathFrom(line);
+                }
+                File target = new File("libraries/"+ entryPath);
                 if (!target.exists()) {
-                    System.out.println("Missing required library: " + entry.path);
+                    System.out.println("Missing required library: " + entryPath);
                     failed = true;
                 }
                 classpath.append(File.pathSeparator).append(target.getAbsolutePath());
@@ -128,8 +134,13 @@ public class Main {
         private final String path;
 
         private static ListEntry from(String line) {
-            String[] parts = line.split("\t", 3);
-            return new ListEntry(parts[0], parts[1], parts[2]);
+            String sha256 = line.substring(0, 64);
+            String[] parts = line.substring(65).split("\t", 2);
+            return new ListEntry(sha256, parts[0], parts[1]);
+        }
+
+        private static String getPathFrom(String line) {
+            return line.substring(65).split("\t", 2)[1];
         }
 
         private ListEntry(String sha256, String id, String path) {

--- a/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
+++ b/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
@@ -133,6 +133,7 @@ public class Main {
 
         private static ListEntry from(String line) {
             String sha256 = line.substring(0, 64);
+            if (line.charAt(65) != '\t') throw new IllegalArgumentException("Invalid bootstrap config line: " + line);
             String[] parts = line.substring(65).split("\t", 2);
             return new ListEntry(sha256, parts[0], parts[1]);
         }

--- a/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
+++ b/bs-shim/src/main/java/net/minecraftforge/bootstrap/shim/Main.java
@@ -46,14 +46,12 @@ public class Main {
                 System.out.println("Loading classpath: ");
             String line = reader.readLine();
             while (line != null) {
-                String entryPath;
-                if (DEBUG) {
-                    ListEntry entry = ListEntry.from(line);
-                    entryPath = entry.path;
-                    System.out.println(entry);
-                } else {
-                    entryPath = ListEntry.getPathFrom(line);
-                }
+                String entryPath = ListEntry.getPathFrom(line);
+//                if (DEBUG) {
+//                    ListEntry entry = ListEntry.from(line);
+//                    entryPath = entry.path;
+//                    System.out.println(entry);
+//                }
                 File target = new File("libraries/"+ entryPath);
                 if (!target.exists()) {
                     System.out.println("Missing required library: " + entryPath);


### PR DESCRIPTION
A couple of trivial optimisations for parsing `bootstrap-shim.list`.

As a reminder, the format looks like this:
```
44611ac70c2517240f5bbfa0c687656503b255ac92f13f269e5567ab2ee4bb1e	com.electronwill.night-config:core:3.7.3	com/electronwill/night-config/core/3.7.3/core-3.7.3.jar
a184314c44dee30296f2ee611c5cd85372211d6c989a1f0585c5c8c2567f0bff	com.electronwill.night-config:toml:3.7.3	com/electronwill/night-config/toml/3.7.3/toml-3.7.3.jar
```

- SHA-256 is always a fixed size, so we can grab that chunk directly instead of searching every character of the hash for a `\t` to split on.
- `ListEntry` appears to only be used for debugging, with a commented out println() call immediately after it. I've adapted the code to avoid allocating new `ListEntry` objects and instead grab the path string directly, while still preserving existing debugging behaviour.