### PR TITLE
Only calculate debug log width when debugging

### DIFF
--- a/src/main/java/net/minecraftforge/bootstrap/Bootstrap.java
+++ b/src/main/java/net/minecraftforge/bootstrap/Bootstrap.java
@@ -198,7 +198,9 @@ public class Bootstrap {
 
         var ret = new ArrayList<SecureJar>();
         var bootlayer = getClass().getModule().getLayer();
-        var width = jars.stream().mapToInt(j -> j.moduleDataProvider().name().length()).max().orElse(0) + 1;
+        int width = DEBUG
+                ? jars.stream().mapToInt(j -> j.moduleDataProvider().name().length()).max().orElse(0) + 1
+                : 0;
 
         if (DEBUG) log("Found classpath:");
         for (int x = 0; x < classpath.size(); x++) {

--- a/src/main/java/net/minecraftforge/bootstrap/Bootstrap.java
+++ b/src/main/java/net/minecraftforge/bootstrap/Bootstrap.java
@@ -206,7 +206,7 @@ public class Bootstrap {
         for (int x = 0; x < classpath.size(); x++) {
             var jar = jars.get(x);
             var name = jar.moduleDataProvider().name();
-            var paths = classpath.get(x);
+            Path[] paths = DEBUG ? classpath.get(x) : null;
 
             if (bootlayer.findModule(name).isPresent()) {
                 log("  Bootstrap: ", width, name, paths);

--- a/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
+++ b/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
@@ -34,7 +34,8 @@ public class ForgeBootstrap extends Bootstrap {
         if (DEBUG) log("Found classpath:");
         for (int x = 0; x < classpath.size(); x++) {
             var jar = jars.get(x);
-            var name = jar.moduleDataProvider().name();
+            var meta = jar.moduleDataProvider();
+            var name = meta.name();
             Path[] paths = DEBUG ? classpath.get(x) : null;
 
             if (bootlayer.findModule(name).isPresent()) {
@@ -43,7 +44,6 @@ public class ForgeBootstrap extends Bootstrap {
             }
 
             // If it's a mod we'll find it later
-            var meta = jar.moduleDataProvider();
             if (meta.findFile(MODS_TOML).isPresent() ||
                 meta.findFile(MINECRAFT).isPresent() ||
                 meta.getManifest().getMainAttributes().getValue(MOD_TYPE) != null) {

--- a/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
+++ b/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
@@ -27,7 +27,9 @@ public class ForgeBootstrap extends Bootstrap {
 
         var ret = new ArrayList<SecureJar>();
         var bootlayer = getClass().getModule().getLayer();
-        var width = jars.stream().mapToInt(j -> j.moduleDataProvider().name().length()).max().orElse(0) + 1;
+        int width = DEBUG
+                ? jars.stream().mapToInt(j -> j.moduleDataProvider().name().length()).max().orElse(0) + 1
+                : 0;
 
         if (DEBUG) log("Found classpath:");
         for (int x = 0; x < classpath.size(); x++) {

--- a/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
+++ b/src/main/java/net/minecraftforge/bootstrap/ForgeBootstrap.java
@@ -35,7 +35,7 @@ public class ForgeBootstrap extends Bootstrap {
         for (int x = 0; x < classpath.size(); x++) {
             var jar = jars.get(x);
             var name = jar.moduleDataProvider().name();
-            var paths = classpath.get(x);
+            Path[] paths = DEBUG ? classpath.get(x) : null;
 
             if (bootlayer.findModule(name).isPresent()) {
                 log("  Bootstrap: ", width, name, paths);


### PR DESCRIPTION
Skips a couple of streams whose results will never be used when DEBUG = false